### PR TITLE
feat: reusable paragraph component

### DIFF
--- a/src/app/components/Paragraph/index.tsx
+++ b/src/app/components/Paragraph/index.tsx
@@ -1,0 +1,29 @@
+import { FC, forwardRef, HTMLAttributes } from "react";
+import { cva, VariantProps } from "class-variance-authority";
+
+const paragraphVariants = cva(
+  "max-w-prose text-slate-700 dark:text-slate-300 mb-2 text-center",
+  {
+    variants: {
+      size: {
+        default: "text-base sm:text-lg",
+        sm: "text-sm, sm:text-base",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+);
+
+interface ParagraphProps
+  extends HTMLAttributes<HTMLParagraphElement>,
+    VariantProps<typeof paragraphVariants> {
+  para: string;
+}
+
+const Paragraph = forwardRef<HTMLParagraphElement, ParagraphProps>(
+  ({ className, size, children, ...props }, ref) => <p ref={ref} {...props}></p>
+);
+
+export default Paragraph;

--- a/src/app/components/Paragraph/index.tsx
+++ b/src/app/components/Paragraph/index.tsx
@@ -1,5 +1,6 @@
 import { FC, forwardRef, HTMLAttributes } from "react";
 import { cva, VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
 
 const paragraphVariants = cva(
   "max-w-prose text-slate-700 dark:text-slate-300 mb-2 text-center",
@@ -18,12 +19,20 @@ const paragraphVariants = cva(
 
 interface ParagraphProps
   extends HTMLAttributes<HTMLParagraphElement>,
-    VariantProps<typeof paragraphVariants> {
-  para: string;
-}
+    VariantProps<typeof paragraphVariants> {}
 
 const Paragraph = forwardRef<HTMLParagraphElement, ParagraphProps>(
-  ({ className, size, children, ...props }, ref) => <p ref={ref} {...props}></p>
+  ({ className, size, children, ...props }, ref) => (
+    <p
+      ref={ref}
+      {...props}
+      className={cn(paragraphVariants({ size, className }))}
+    >
+      {children}
+    </p>
+  )
 );
+
+Paragraph.displayName = `Paragraph`;
 
 export default Paragraph;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,4 @@
+import { ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));


### PR DESCRIPTION
### Description 
- Task link :- https://www.notion.so/js-shinobis/FE-Reusable-Paragraph-Component-03321006e1024f94819a8c64078c5f3e?pvs=4
- Reusable paragraph component with multiple variants
- Utilizing the dependencies `clsx`, `class-variance-authority` & `tailwind-merge`

